### PR TITLE
remove reflection

### DIFF
--- a/src/flatland/ordered/map.clj
+++ b/src/flatland/ordered/map.clj
@@ -12,6 +12,7 @@
                          IHashEq
                          IObj
                          IFn
+                         ISeq
                          MapEquivalence
                          Reversible
                          MapEntry
@@ -24,7 +25,7 @@
 ;; an AOT issue using this way instead.
 (def hasheq-ordered-map
   (or (resolve 'clojure.core/hash-unordered-coll)
-      (fn old-hasheq-ordered-map [m]
+      (fn old-hasheq-ordered-map [^ISeq m]
         (reduce (fn [acc ^MapEntry e]
                   (let [k (.key e), v (.val e)]
                     (unchecked-add ^Integer acc ^Integer (bit-xor (hash k) (hash v)))))

--- a/src/flatland/ordered/set.clj
+++ b/src/flatland/ordered/set.clj
@@ -3,7 +3,7 @@
   (:require [clojure.string :as s])
   (:import (clojure.lang IPersistentSet ITransientSet IEditableCollection
                          IPersistentMap ITransientMap ITransientAssociative
-                         IPersistentVector ITransientVector IHashEq
+                         IPersistentVector ITransientVector IHashEq ISeq
                          Associative SeqIterator Reversible IFn IObj)
            (java.util Set Collection)))
 
@@ -13,7 +13,7 @@
 ;; an AOT issue using this way instead.
 (def hasheq-ordered-set
   (or (resolve 'clojure.core/hash-unordered-coll)
-      (fn old-hasheq-ordered-set [s]
+      (fn old-hasheq-ordered-set [^ISeq s]
         (reduce + (map hash (.seq s))))))
 
 (deftype OrderedSet [^IPersistentMap k->i


### PR DESCRIPTION
These code paths probably aren't used anymore, but the reflection warnings
still show up for anyone trying to run `lein check`