### PR TITLE
Add type hint to toArray to resolve ambiguity in JDK 11

### DIFF
--- a/src/flatland/ordered/set.clj
+++ b/src/flatland/ordered/set.clj
@@ -79,7 +79,7 @@
     (.count this))
   (isEmpty [this]
     (zero? (.count this)))
-  (toArray [this dest]
+  (^objects toArray [this ^objects dest]
     (reduce (fn [idx item]
               (aset dest idx item)
               (inc idx))


### PR DESCRIPTION
Without this type hint, JDK 11 complains:

    java.lang.IllegalArgumentException: Must hint overloaded method: toArray